### PR TITLE
Updated extension to support Manifest V3 + Updated Shopify request URL (outdated)

### DIFF
--- a/content.js
+++ b/content.js
@@ -20,7 +20,7 @@ if (typeof Shopify != 'undefined') {
   */
   var partnerID;
   if(partnerID !== undefined){
-    log('%c 👉 https://partners.shopify.com/' + partnerID + '/managed_stores/new?shop_domain=' + Shopify.shop, defaultStyle);
+    log('%c 👉 https://partners.shopify.com/' + partnerID + '/managed_stores/new?store_domain=' + Shopify.shop, defaultStyle);
   }
 
 } 

--- a/inject.js
+++ b/inject.js
@@ -5,4 +5,5 @@ function injectScript(file_path, tag) {
     script.setAttribute('src', file_path);
     node.appendChild(script);
 }
-injectScript(chrome.extension.getURL('content.js'), 'body');
+
+injectScript(chrome.runtime.getURL('content.js'), 'body');

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-   "browser_action": {
+   "action": {
       "default_icon": "icon.png"
    },
    "content_scripts": [ 

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
    } ],
    "web_accessible_resources": ["content.js"],
    "name": "Shopify Theme Validator",
+   "manifest_version": 3,
    "permissions": [ "tabs" ],
    "short_name": "Shopify Theme Validator",
    "version": "0.1"

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,6 @@
       "run_at": "document_end"
    } ],
    "web_accessible_resources": ["content.js"],
-   "manifest_version": 2,
    "name": "Shopify Theme Validator",
    "permissions": [ "tabs" ],
    "short_name": "Shopify Theme Validator",

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,19 @@
    "browser_action": {
       "default_icon": "icon.png"
    },
-   "content_scripts": [ {
-      "js": [ "inject.js" ],
-      "matches": [ "\u003Call_urls>" ],
-      "run_at": "document_end"
-   } ],
-   "web_accessible_resources": ["content.js"],
+   "content_scripts": [ 
+      {
+         "js": [ "inject.js" ],
+         "matches": [ "<all_urls>" ],
+         "run_at": "document_end"
+      } 
+   ],
+   "web_accessible_resources": [
+      {
+         "resources": ["content.js"],
+         "matches": ["<all_urls>"]
+      }
+   ],
    "name": "Shopify Theme Validator",
    "manifest_version": 3,
    "permissions": [ "tabs" ],

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
    "manifest_version": 3,
    "permissions": [ "tabs" ],
    "short_name": "Shopify Theme Validator",
-   "version": "0.1"
+   "version": "0.2"
 }


### PR DESCRIPTION
- Updated the extension to support [Manifest V3] (Adopted in 2024)(https://developer.chrome.com/docs/extensions/develop/migrate/manifest)
- Updated Shopify request URL. https://partners.shopify.com/XXXXX/managed_stores/new?shop_domain=xxxx.myshopify.com doesn't work anymore. https://partners.shopify.com/XXXXX/managed_stores/new?store_domain=xxxx.myshopify.com should be used instead